### PR TITLE
Update Auto Pipeline Stack & Rename Default Branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         }
         stage('Apply Terraform Plan') {
             when {
-                branch 'master'
+                branch 'main'
             } 
             steps {
                 sh label: 'Apply Terraform plan changes', script: 'make apply'
@@ -43,7 +43,7 @@ pipeline {
         }
         stage('Integration Tests') {
             when {
-                branch 'master'
+                branch 'main'
             }
             steps {
                 sleep(time:30, unit:"SECONDS") // Wait 30 seconds for DDNS daemon set to register new address, if applicable.
@@ -52,8 +52,8 @@ pipeline {
         }
         stage('Update Gated Pipeline') {
             when {
-                allOf { // Submit PR to gated environment pipeline when commit/merge to master branch is prefixed with [PROMOTE]
-                    branch 'master'
+                allOf { // Submit PR to gated environment pipeline when commit/merge to main branch is prefixed with [PROMOTE]
+                    branch 'main'
                     changelog '^\\[PROMOTE\\] .+$'
                 }
             }
@@ -82,7 +82,7 @@ pipeline {
             }
             post {
                 cleanup {
-                    sh label: 'Revert to local master branch', script: 'git checkout master'
+                    sh label: 'Revert to local main branch', script: 'git checkout main'
                     sh label: 'Delete local scoreboard branch', script: 'git branch -D scoreboard'
                     sh label: 'Remove git config', script: 'rm .git/config'
                     sh label: 'Remove gated repo clone', script: 'rm -rf gated/'
@@ -103,7 +103,7 @@ pipeline {
                      description: 'All tests passed',
                      targetUrl: "${env.BUILD_URL}/display/redirect")
 
-                    // Attempt to auto-merge this PR into master unless the 'no-merge' label exists to indicate otherwise.
+                    // Attempt to auto-merge this PR into main unless the 'no-merge' label exists to indicate otherwise.
                     if (! pullRequest.labels.contains("no-merge")) {
                         echo "No-merge label absent; attempting auto-merge."
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ This [Terraform HCL](./main.tf) is effectively a wrapper to deploy a specific ve
 #### Changes Workflow
 
 1. Human or application pipeline updates Terraform HCL/variables in feature branch and submits pull request.
-1. Jenkins examines pull request, runs Terraform validation tests, then merges into master upon success.
-1. Jenkins examines master branch, repeats validation tests, applies Terraform plan in the live environment, and runs integration tests.
+1. Jenkins examines pull request, runs Terraform validation tests, then merges into `main` upon success.
+1. Jenkins examines `main` branch, repeats validation tests, applies Terraform plan in the live environment, and runs integration tests.
 1. (Optional) If tests succeed and the Git commit message contains the magic word ```[PROMOTE]```, submit an upgrade request to the [gated environment](https://github.com/mikeroach/iac-pipeline-gated) via that repository's [GitOps Helper script](https://github.com/mikeroach/iac-pipeline-gated/gitops-helper.sh).

--- a/gitops-helper.sh
+++ b/gitops-helper.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
-# Proof-of-concept poor man's GitOps helper script.
+# Proof-of-concept budget SRE's GitOps helper script.
 # Intended to be invoked by an application's CI job after all deploy tests
-# pass in master branch, and later during multi-stage infrastructure pipelines.
+# pass in main branch, and later during multi-stage infrastructure pipelines.
 
 # Yes, this is awkward and better done with a real delivery system like Jenkins-X,
 # Weaveworks Flux, Argo CD, or Spinnaker (or one pipeline for all environments).
@@ -15,7 +15,7 @@ version="20191005.1"
 usage="
 Usage: $0 -s [service] -v [version] -u [URL] [-d] [-p]
 	-h  display this help message
-	-d  commit directly to master without a pull request branch (set GITHUB_TOKEN environment variable when using default branch mode)
+	-d  commit directly to main without a pull request branch (set GITHUB_TOKEN environment variable when using default branch mode)
 	-p  promote new version/value to gated infrastructure pipeline (Jenkins job will submit pull request)
 	-s  service (or Terraform variable key) to update
 	-u  URL detailing this update (i.e. Jenkins job of originating application pipeline)
@@ -107,15 +107,15 @@ if [ "$promote" == "yes" ] ; then
 	git add scoreboard/${service}-${version}
 	git commit -m "Add lock for update of $service to $version"
 	git push -u origin scoreboard
-	git checkout master
-	git reset --hard origin/master
+	git checkout main
+	git reset --hard origin/main
 fi
 
-# Create a new branch if we're operating in pull request mode, otherwise update master directly.
+# Create a new branch if we're operating in pull request mode, otherwise update main directly.
 if [ "$git_mode" == "branch" ] ; then
 	git checkout -b ${service}-${version}
 else
-	git checkout master
+	git checkout main
 fi
 
 # Update component version with cutting edge DevOps string manipulation techniques.
@@ -128,10 +128,10 @@ else
 	git commit -m "Request update of $service to $version"
 fi
 
-# Push our branch and submit pull request if operating in pull request mode, otherwise update master directly.
+# Push our branch and submit pull request if operating in pull request mode, otherwise update main directly.
 if [ "$git_mode" == "branch" ] ; then
 	git push -u origin ${service}-${version}
 	hub pull-request -m "Request update of $service to $version" -m "Details about this version are available at: $job_url"
 else
-	git push -u origin master
+	git push -u origin main
 fi

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 module "environment-auto" {
-  source                            = "github.com/mikeroach/iac-template-pipeline?ref=v17"
+  source                            = "github.com/mikeroach/iac-template-pipeline?ref=v3"
   dns_hostname                      = var.dns_hostname
   dns_domain                        = var.dns_domain
   dockerhub_credentials             = var.dockerhub_credentials


### PR DESCRIPTION
This PR:

* Updates the repository's default branch to `main` in code and documentation to embrace recommended inclusive terminology per [IETF Internet-Draft draft-knodel-terminology-12](https://datatracker.ietf.org/doc/draft-knodel-terminology/).
* Applies the latest IaC template stack to receive 3 years' worth of updates as described in https://github.com/mikeroach/iac-template-pipeline/pull/1 and https://github.com/mikeroach/iac-template-pipeline/pull/2 .